### PR TITLE
Fix direct message query

### DIFF
--- a/src/services/direct-message-service/direct-message-service.ts
+++ b/src/services/direct-message-service/direct-message-service.ts
@@ -15,13 +15,14 @@ export async function fetchDirectMessages(userId: string, otherUserId: string): 
 
     const { data, error } = await supabase
       .from("direct_messages")
-      .select(`
-        *,
+      .select(
+        `*,
         sender:sender_id(username, avatar_url),
-        recipient:recipient_id(username, avatar_url)
-      `)
-      .or(`sender_id.eq.${userId},recipient_id.eq.${userId}`)
-      .or(`sender_id.eq.${otherUserId},recipient_id.eq.${otherUserId}`)
+        recipient:recipient_id(username, avatar_url)`,
+      )
+      .or(
+        `and(sender_id.eq.${userId},recipient_id.eq.${otherUserId}),and(sender_id.eq.${otherUserId},recipient_id.eq.${userId})`,
+      )
       .order("created_at", { ascending: true })
 
     if (error) {


### PR DESCRIPTION
## Summary
- fix filtering logic in fetchDirectMessages

## Testing
- `pnpm install --frozen-lockfile`
- `npx tsc --noEmit` *(fails: Property 'admin' does not exist on type..., etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684606b8fec8832d880610c9f005108f